### PR TITLE
Make project compile on OSX 10.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+Makefile
+CMakeFiles
+CMakeCache.txt
+compile_commands.json
+*.cmake
+*.a
+*.o
+*.cbp
+src/hdpmanager
+tests/unittests
+
+#ignore leveldb test and benchmarks
+external/leveldb/*_test
+external/leveldb/*_bench*
+external/leveldb/include/port
+external/leveldb/leveldbutil

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+add_subdirectory(external/leveldb)
 add_compile_options(-Wall -Wextra -Wpedantic)
 
 # TODO: add CMakeLists.txt (or at least proper generation) to cryptopp
 add_library(cryptopp STATIC IMPORTED)
 set_target_properties(cryptopp PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/external/cryptopp/libcryptopp.a)
-
-add_subdirectory(external/leveldb)
 
 include_directories(.)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# Hierarchical deterministic password manager
+
+## Compilation Instructions
+
+**MACOS (10.15)**  
+This project requires an `ncurses` implementation, you can use homebrew to get one:
+```bash
+$ brew install ncurses
+```
+Then it's time to compile with:
+```bash
+$ cmake .
+$ make
+```
 ## What is this password manager
 
 This is a proof-of-concept deterministic mnemonic-based password manager. It utilizes the seed generated from mnemonic<sup>\[[2](#BIP-39)\]</sup> to provision secrets<sup>\[[1](#BIP-32)\]</sup> (as of now - passwords). This allows for synchronization of passwords across devices without the need to store _any_ secrets on third-party servers. After synchronization of the metadata (password groups, names and details) via third-party servers, the passwords are generated from mnemonic inputted by the user on each new device.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,5 @@
 # Hierarchical deterministic password manager
 
-## Compilation Instructions
-
-**MACOS (10.15)**  
-This project requires an `ncurses` implementation, you can use homebrew to get one:
-```bash
-$ brew install ncurses
-```
-Then it's time to compile with:
-```bash
-$ cmake .
-$ make
-```
 ## What is this password manager
 
 This is a proof-of-concept deterministic mnemonic-based password manager. It utilizes the seed generated from mnemonic<sup>\[[2](#BIP-39)\]</sup> to provision secrets<sup>\[[1](#BIP-32)\]</sup> (as of now - passwords). This allows for synchronization of passwords across devices without the need to store _any_ secrets on third-party servers. After synchronization of the metadata (password groups, names and details) via third-party servers, the passwords are generated from mnemonic inputted by the user on each new device.
@@ -47,6 +35,20 @@ Build requirements: cmake, gcc>=8 or clang>=6, ncursesw.
 
 Develompent: all of the above + clang-tidy and clang-format.
 
+## Compilation Instructions
+
+**MACOS (10.15)**  
+This project requires an `ncurses` implementation, you can use homebrew to get one:
+```bash
+$ brew install ncurses
+```
+Then it's time to compile with:
+```bash
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
+```
 
 ## License
 

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -17,10 +17,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ]]
 set(CURSES_NEED_NCURSES TRUE)
-set(CURSES_NEED_WIDE TRUE)
+
+# The packaged ncurses in macosx homebrew are already containing wide-char support
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(CURSES_NEED_WIDE TRUE)
+endif()
 
 find_package(Curses REQUIRED)
-
 include_directories(${CURSES_INCLUDE_DIR})
 
 add_library(cli form_controller.cpp color.cpp output.cpp menu.cpp input.cpp manager.cpp new_keychain_screen.cpp keychain_main_screen.cpp error_screen.cpp start_screen.cpp help_screen.cpp)

--- a/src/keychain/CMakeLists.txt
+++ b/src/keychain/CMakeLists.txt
@@ -19,4 +19,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 include_directories(${LEVELDB_PUBLIC_INCLUDE_DIR})
 
 add_library(keychain STATIC keychain.cpp db.cpp keychain_entry.cpp)
-target_link_libraries(keychain PUBLIC stdc++fs crypto PRIVATE leveldb utils)
+
+# With OSX 10.15 stdc++fs is build in in libc++, no need to link it separately
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(keychain PUBLIC crypto PRIVATE leveldb utils)
+else()
+    target_link_libraries(keychain PUBLIC stdc++fs crypto PRIVATE leveldb utils)
+endif()


### PR DESCRIPTION
This PR makes it possible to compile for mac systems. At the moment the only supported version is MACOS 10.15 cause it ships the first XCode version that contains an implementation of `std::filesystem`. In theory, it is possible to link it for previous OSX versions but it needs further work.